### PR TITLE
feat(BlReaderWork): Added restartSyncerOnError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ List of fields in v1alpha2 configuration:
 | `server.host`                         | `string`              | Hostname or IP address where the server runs.                                         |
 | `server.port`                         | `uint32`              | TCP port the server listens on.                                                       |
 | `server.stopInError`                  | `bool`                | Whether to stop the server when a fatal error occurs.                                 |
-| `server.restartSyncerOnError`         | `bool`                | Restart the syncer from the latest position when there are an error reading binlog.   |
+| `server.restartSyncerOnError`         | `bool`                | Restart the syncer from the latest position when there is an error reading binlog.   |
 | `server.senderWorkers`                | `uint32`              | Number of sender workers. Set it to 1 to preserve event order.                        |
 | `server.pool.size`                    | `uint32`              | Size of the internal worker pool.                                                     |
 | `server.pool.itemByRow`               | `bool`                | Boolean to add in pool an item by row in a single operation or the full list of rows. |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ List of fields in v1alpha2 configuration:
 | `server.host`                         | `string`              | Hostname or IP address where the server runs.                                         |
 | `server.port`                         | `uint32`              | TCP port the server listens on.                                                       |
 | `server.stopInError`                  | `bool`                | Whether to stop the server when a fatal error occurs.                                 |
+| `server.restartSyncerOnError`         | `bool`                | Restart the syncer from the latest position when there are an error reading binlog.   |
 | `server.senderWorkers`                | `uint32`              | Number of sender workers. Set it to 1 to preserve event order.                        |
 | `server.pool.size`                    | `uint32`              | Size of the internal worker pool.                                                     |
 | `server.pool.itemByRow`               | `bool`                | Boolean to add in pool an item by row in a single operation or the full list of rows. |
@@ -200,6 +201,7 @@ configMap:
         host: "127.0.0.1"
         port: 8080
         stopInError: true
+        restartSyncerOnError: false
         senderWorkers: 10
         pool:
           size: 20

--- a/api/v1alpha2/config.go
+++ b/api/v1alpha2/config.go
@@ -42,13 +42,14 @@ type LoggerT struct {
 
 // ServerT
 type ServerT struct {
-	ID            string       `yaml:"id"`
-	Host          string       `yaml:"host"`
-	Port          uint32       `yaml:"port"`
-	StopInError   bool         `yaml:"stopInError"`
-	Pool          ServerPoolT  `yaml:"pool"`
-	Cache         ServerCacheT `yaml:"cache"`
-	SenderWorkers uint32       `yaml:"senderWorkers"`
+	ID                   string       `yaml:"id"`
+	Host                 string       `yaml:"host"`
+	Port                 uint32       `yaml:"port"`
+	StopInError          bool         `yaml:"stopInError"`
+	RestartSyncerOnError bool         `yaml:"restartSyncerOnError"`
+	Pool                 ServerPoolT  `yaml:"pool"`
+	Cache                ServerCacheT `yaml:"cache"`
+	SenderWorkers        uint32       `yaml:"senderWorkers"`
 }
 
 type ServerPoolT struct {

--- a/docs/binwatch.v1alpha2.yaml
+++ b/docs/binwatch.v1alpha2.yaml
@@ -6,6 +6,7 @@ server:
   host: "0.0.0.0" # api server host
   port: 8080 # api server port
   stopInError: true # stop execution in error or continue
+  restartSyncerOnError: false # restart syncer from beginning of current binlog on error (takes precedence over stopInError)
   senderWorkers: 1 # number of workers to send the events. Select 1 for sending events in order
   pool:
     size: 20 # event item pool size

--- a/internal/binwatch/blreaderwork/blreaderwork.go
+++ b/internal/binwatch/blreaderwork/blreaderwork.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 
 	"binwatch/api/v1alpha2"
 	"binwatch/internal/cache"
@@ -141,27 +140,53 @@ func (w *BLReaderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 				e, err = w.mysql.blStream.GetEvent(ctx)
 				if err != nil {
 					if err != context.Canceled {
+						extra.Set("binlogPosition", w.mysql.blLoc.Pos)
+						extra.Set("binlogFile", w.mysql.blLoc.Name)
 						w.log.Error("error in get binlog event", extra, err, w.cfg.Server.StopInError)
+						extra.Del("binlogPosition")
+						extra.Del("binlogFile")
 
-						w.log.Info("restarting syncer", extra)
-						w.mysql.blSyncer.Close()
-						time.Sleep(5 * time.Second)
+						// Restart syncer if RestartSyncerOnError is true
+						if !w.cfg.Server.RestartSyncerOnError {
 
-						w.mysql.blSyncer = replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
-							Flavor:          w.cfg.Source.Flavor,
-							ServerID:        w.cfg.Source.ServerID,
-							Host:            w.cfg.Source.Host,
-							Port:            uint16(w.cfg.Source.Port),
-							User:            w.cfg.Source.User,
-							Password:        w.cfg.Source.Password,
-							ReadTimeout:     w.cfg.Source.ReadTimeout,
-							HeartbeatPeriod: w.cfg.Source.HeartbeatPeriod,
-							Logger:          logger.DummyLogger{},
-						})
+							w.log.Info("restarting syncer", extra)
+							w.mysql.blSyncer.Close()
 
-						w.mysql.blStream, err = w.mysql.blSyncer.StartSync(w.mysql.blLoc)
-						if err != nil {
-							w.log.Error("unable to restart syncer", extra, err, true)
+							// Get current binlog location without cache in order to avoid infinite loop
+							w.mysql.blLoc, err = utils.GetCurrentBinlogLocation(&canal.Config{
+								ServerID: w.cfg.Source.ServerID,
+								Flavor:   w.cfg.Source.Flavor,
+								Addr:     fmt.Sprintf("%s:%d", w.cfg.Source.Host, w.cfg.Source.Port),
+								User:     w.cfg.Source.User,
+								Password: w.cfg.Source.Password,
+								Logger:   logger.DummyLogger{},
+							})
+							if err != nil {
+								w.log.Error("error getting current binlog location", extra, err, true)
+							}
+
+							// Restart syncer
+							w.mysql.blSyncer = replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+								Flavor:          w.cfg.Source.Flavor,
+								ServerID:        w.cfg.Source.ServerID,
+								Host:            w.cfg.Source.Host,
+								Port:            uint16(w.cfg.Source.Port),
+								User:            w.cfg.Source.User,
+								Password:        w.cfg.Source.Password,
+								ReadTimeout:     w.cfg.Source.ReadTimeout,
+								HeartbeatPeriod: w.cfg.Source.HeartbeatPeriod,
+								Logger:          logger.DummyLogger{},
+							})
+
+							extra.Set("binlogPosition", w.mysql.blLoc.Pos)
+							extra.Set("binlogFile", w.mysql.blLoc.Name)
+							w.log.Info("syncer restarted from new position", extra)
+							extra.Del("binlogPosition")
+							extra.Del("binlogFile")
+							w.mysql.blStream, err = w.mysql.blSyncer.StartSync(w.mysql.blLoc)
+							if err != nil {
+								w.log.Error("unable to restart syncer", extra, err, true)
+							}
 						}
 					}
 					continue

--- a/internal/binwatch/blreaderwork/blreaderwork.go
+++ b/internal/binwatch/blreaderwork/blreaderwork.go
@@ -147,7 +147,7 @@ func (w *BLReaderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 						extra.Del("binlogFile")
 
 						// Restart syncer if RestartSyncerOnError is true
-						if !w.cfg.Server.RestartSyncerOnError {
+						if w.cfg.Server.RestartSyncerOnError {
 
 							w.log.Info("restarting syncer", extra)
 							w.mysql.blSyncer.Close()


### PR DESCRIPTION
This pull request introduces a new feature to handle errors in binlog synchronization by adding a `restartSyncerOnError` configuration option. It also includes related code changes to implement and document this feature.

### New Feature: Error Handling for Binlog Synchronization
* **Configuration Option Added**:
  - Added `restartSyncerOnError` field to the server configuration in `README.md`, `config.go`, and `docs/binwatch.v1alpha2.yaml`. This option allows the syncer to restart from the latest binlog position on errors instead of stopping. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R204) [[3]](diffhunk://#diff-1a74fc56e4add497f2f0c23c4f829e0fba18d215227abafef668f011e8aaee07R49) [[4]](diffhunk://#diff-84e0eeb0d55abb2e60d97f081ef2fe4e6b03c948d563aef202e6f9ce621cd94cR9)

* **Implementation in Binlog Reader**:
  - Updated `BLReaderWorkT.Run` in `blreaderwork.go` to check the `restartSyncerOnError` flag. If enabled, the syncer restarts from the current binlog position after an error. Added logging for binlog position and file during the restart process. [[1]](diffhunk://#diff-ce94456c0bd5382cb27b872e68c78fd9246e4c2814b291abc33d98396d8736cdR143-R168) [[2]](diffhunk://#diff-ce94456c0bd5382cb27b872e68c78fd9246e4c2814b291abc33d98396d8736cdR181-R191)

### Code Cleanup
* **Unused Import Removed**:
  - Removed the unused `time` package import from `blreaderwork.go`.