### PR TITLE
feat(sharding): horizontally shard events across N parallel instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ List of fields in v1alpha2 configuration:
 | `routes[].operations`                 | `[]string`            | List of database operations to route (INSERT, UPDATE, DELETE).                        |
 | `routes[].template`                   | `string`              | Go template used to render the message sent by the route.                             |
 | `routes[].dbTable`                    | `string`              | Database.Table name to send to the connector (e.g., "db.table" ).                     |
+| `sharding.enabled`                    | `bool`                | Enable horizontal sharding of events across N parallel instances.                     |
+| `sharding.count`                      | `uint64`              | Total number of shards. Typically the StatefulSet replicaCount.                       |
+| `sharding.index`                      | `uint64`              | This instance's shard index, 0..count-1. Usually injected from the pod ordinal.       |
+| `sharding.keyTemplate`                | `string`              | Optional Go template to derive the shard key. Empty = hash by BinlogPosition.         |
 
 ## Standalone
 

--- a/api/v1alpha2/config.go
+++ b/api/v1alpha2/config.go
@@ -23,8 +23,27 @@ type ConfigT struct {
 	Logger     LoggerT      `yaml:"logger"`
 	Server     ServerT      `yaml:"server"`
 	Source     SourceT      `yaml:"source"`
+	Sharding   ShardingT    `yaml:"sharding"`
 	Connectors []ConnectorT `yaml:"connectors"`
 	Routes     []RouteT     `yaml:"routes"`
+}
+
+/*
+ *  Sharding configuration
+ */
+
+// ShardingT allows running the same binwatch config in N parallel instances
+// where each instance only processes its own slice of events. Useful to scale
+// the sender horizontally without duplicating writes downstream.
+//
+// Index and Count are usually injected via env vars (e.g. from a StatefulSet
+// pod ordinal) using ${ENV:VAR}$ substitution, so the same YAML can be reused
+// across all replicas.
+type ShardingT struct {
+	Enabled     bool   `yaml:"enabled"`
+	Count       uint64 `yaml:"count"`
+	Index       uint64 `yaml:"index"`
+	KeyTemplate string `yaml:"keyTemplate"`
 }
 
 /*

--- a/docs/binwatch.v1alpha2.yaml
+++ b/docs/binwatch.v1alpha2.yaml
@@ -38,6 +38,15 @@ source:
   #   position: 4 # binlog position in file to start
 
 
+sharding:
+  enabled: false # enable horizontal sharding of events across N instances
+  count: 1 # total number of shards (typically the StatefulSet replicaCount)
+  index: 0 # this instance's shard index, 0..count-1 (usually injected from pod ordinal)
+  # Optional: Go template used to compute the shard key per event. If empty,
+  # BinlogPosition is used (even distribution, no row-affinity).
+  # Recommended: hash by primary key so all updates to the same row share a shard.
+  keyTemplate: "" # e.g. '{{ (index .Data.Rows 0).id }}'
+
 connectors:
 - name: webhook-upsert # connector name
   type: webhook # connector type: webhook|google_pubsub

--- a/internal/binwatch/blsenderwork/blsenderwork.go
+++ b/internal/binwatch/blsenderwork/blsenderwork.go
@@ -3,6 +3,7 @@ package blsenderwork
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 	"slices"
@@ -113,38 +114,38 @@ func NewBinlogSenderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 // shouldProcess returns true if the given event belongs to this shard.
 // When sharding is disabled it always returns true.
 //
-// If a KeyTemplate is configured, it is rendered against the event and the
-// resulting bytes are hashed (FNV-1a 64) to derive the bucket. This keeps
-// related events (e.g. all updates to the same row PK) on the same shard.
-//
-// If no KeyTemplate is set, BinlogPosition is used as the bucket key, which
-// distributes load evenly but does not guarantee same-row affinity.
+// The shard key is always hashed through FNV-1a 64 before the modulo to keep
+// the distribution balanced. If a KeyTemplate is configured, it is rendered
+// against the event and the rendered bytes are hashed — same-key events (e.g.
+// all updates to the same row PK) always land on the same shard. If no
+// KeyTemplate is set, the 8 bytes of BinlogPosition are hashed. BinlogPosition
+// is a byte offset within the binlog file (not an event counter), so events
+// of similar size step by similar amounts; hashing first avoids pathological
+// modulo collisions when the step happens to share a common factor with
+// shardCount.
 func (w *BLSenderWorkT) shouldProcess(item *pools.RowEventItemT) bool {
 	if !w.shardEnabled {
 		return true
 	}
 
-	var bucket uint64
+	h := fnv.New64a()
 	if w.shardKeyTmpl != nil {
 		buf := new(bytes.Buffer)
 		if err := w.shardKeyTmpl.Execute(buf, item); err != nil {
-			// On template error: fail-open (process), and log. Dropping
-			// silently would risk losing events; processing on every shard
-			// would duplicate. We pick "this shard handles it" so at least
-			// one shard sends it.
+			// Template errors are deterministic for a given event, so every
+			// replica takes this same BinlogPosition fallback path and they
+			// agree on the owner shard — no duplication, no loss.
 			extra := utils.GetBasicLogExtraFields(componentName)
 			w.log.Error("error rendering sharding.keyTemplate, falling back to BinlogPosition", extra, err, false)
-			bucket = item.Log.BinlogPosition
+			_ = binary.Write(h, binary.LittleEndian, item.Log.BinlogPosition)
 		} else {
-			h := fnv.New64a()
 			_, _ = h.Write(buf.Bytes())
-			bucket = h.Sum64()
 		}
 	} else {
-		bucket = item.Log.BinlogPosition
+		_ = binary.Write(h, binary.LittleEndian, item.Log.BinlogPosition)
 	}
 
-	return bucket%w.shardCount == w.shardIndex
+	return h.Sum64()%w.shardCount == w.shardIndex
 }
 
 func (w *BLSenderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {

--- a/internal/binwatch/blsenderwork/blsenderwork.go
+++ b/internal/binwatch/blsenderwork/blsenderwork.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/fnv"
 	"slices"
 	"sync"
 	"text/template"
@@ -29,6 +30,11 @@ type BLSenderWorkT struct {
 	cach   cache.CacheI
 	conns  map[string]connectors.ConnectorI
 	routs  []routeT
+
+	shardEnabled bool
+	shardCount   uint64
+	shardIndex   uint64
+	shardKeyTmpl *template.Template
 }
 
 type routeT struct {
@@ -47,6 +53,28 @@ func NewBinlogSenderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 		rePool: rePool,
 		conns:  make(map[string]connectors.ConnectorI),
 		cach:   cach,
+
+		shardEnabled: cfg.Sharding.Enabled,
+		shardCount:   cfg.Sharding.Count,
+		shardIndex:   cfg.Sharding.Index,
+	}
+
+	if w.shardEnabled {
+		if w.shardCount == 0 {
+			err = fmt.Errorf("sharding enabled but 'sharding.count' is zero")
+			return w, err
+		}
+		if w.shardIndex >= w.shardCount {
+			err = fmt.Errorf("sharding 'index' (%d) must be lower than 'count' (%d)", w.shardIndex, w.shardCount)
+			return w, err
+		}
+		if cfg.Sharding.KeyTemplate != "" {
+			w.shardKeyTmpl, err = tmpl.NewTemplate("sharding-key", cfg.Sharding.KeyTemplate)
+			if err != nil {
+				err = fmt.Errorf("error parsing 'sharding.keyTemplate': %w", err)
+				return w, err
+			}
+		}
 	}
 
 	for _, connv := range cfg.Connectors {
@@ -82,6 +110,43 @@ func NewBinlogSenderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 	return w, err
 }
 
+// shouldProcess returns true if the given event belongs to this shard.
+// When sharding is disabled it always returns true.
+//
+// If a KeyTemplate is configured, it is rendered against the event and the
+// resulting bytes are hashed (FNV-1a 64) to derive the bucket. This keeps
+// related events (e.g. all updates to the same row PK) on the same shard.
+//
+// If no KeyTemplate is set, BinlogPosition is used as the bucket key, which
+// distributes load evenly but does not guarantee same-row affinity.
+func (w *BLSenderWorkT) shouldProcess(item *pools.RowEventItemT) bool {
+	if !w.shardEnabled {
+		return true
+	}
+
+	var bucket uint64
+	if w.shardKeyTmpl != nil {
+		buf := new(bytes.Buffer)
+		if err := w.shardKeyTmpl.Execute(buf, item); err != nil {
+			// On template error: fail-open (process), and log. Dropping
+			// silently would risk losing events; processing on every shard
+			// would duplicate. We pick "this shard handles it" so at least
+			// one shard sends it.
+			extra := utils.GetBasicLogExtraFields(componentName)
+			w.log.Error("error rendering sharding.keyTemplate, falling back to BinlogPosition", extra, err, false)
+			bucket = item.Log.BinlogPosition
+		} else {
+			h := fnv.New64a()
+			_, _ = h.Write(buf.Bytes())
+			bucket = h.Sum64()
+		}
+	} else {
+		bucket = item.Log.BinlogPosition
+	}
+
+	return bucket%w.shardCount == w.shardIndex
+}
+
 func (w *BLSenderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 	defer wg.Done()
 	extra := utils.GetBasicLogExtraFields(componentName)
@@ -108,6 +173,10 @@ func (w *BLSenderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 					continue
 				}
 				extra.Set("event", item)
+
+				if !w.shouldProcess(item) {
+					continue
+				}
 
 				for ri := range w.routs {
 					if slices.Contains(w.routs[ri].ops, item.Data.Operation) &&

--- a/internal/binwatch/blsenderwork/blsenderwork_test.go
+++ b/internal/binwatch/blsenderwork/blsenderwork_test.go
@@ -49,7 +49,7 @@ func TestShouldProcess_DisabledAcceptsAll(t *testing.T) {
 }
 
 // BinlogPosition fallback: each event is routed to exactly one shard, and
-// every event lands on some shard (partition coverage).
+// the load spreads roughly evenly across shards once it's hashed.
 func TestShouldProcess_BinlogPositionPartitionsAllEvents(t *testing.T) {
 	const count uint64 = 3
 	workers := []*BLSenderWorkT{
@@ -58,12 +58,13 @@ func TestShouldProcess_BinlogPositionPartitionsAllEvents(t *testing.T) {
 		newTestWorker(t, count, 2, ""),
 	}
 
-	counts := map[uint64]int{}
-	for pos := uint64(0); pos < 300; pos++ {
+	counts := make([]int, count)
+	const total = 3000
+	for pos := uint64(1); pos <= total; pos++ {
 		matches := 0
 		for idx, w := range workers {
 			if w.shouldProcess(itemAtPos(pos)) {
-				counts[uint64(idx)]++
+				counts[idx]++
 				matches++
 			}
 		}
@@ -72,10 +73,49 @@ func TestShouldProcess_BinlogPositionPartitionsAllEvents(t *testing.T) {
 		}
 	}
 
-	// 300 events, 3 shards -> 100 each.
+	expected := total / int(count)
+	tolerance := expected / 5 // 20% skew tolerance after FNV-1a hashing
 	for idx, c := range counts {
-		if c != 100 {
-			t.Errorf("shard %d processed %d events, want 100 (BinlogPosition is sequential so distribution is exact)", idx, c)
+		if c < expected-tolerance || c > expected+tolerance {
+			t.Errorf("shard %d processed %d events, want ~%d (±%d)", idx, c, expected, tolerance)
+		}
+	}
+}
+
+// Regression test: BinlogPosition is a byte offset in the binlog file, so
+// consecutive events advance by similar deltas. With raw `pos % count` and
+// an even step (e.g. 150-byte events with count=2), every event would land
+// on the same shard. Hashing through FNV-1a before the modulo must keep the
+// distribution balanced.
+func TestShouldProcess_BinlogPositionByteOffsetEvenStep(t *testing.T) {
+	const count uint64 = 2
+	workers := []*BLSenderWorkT{
+		newTestWorker(t, count, 0, ""),
+		newTestWorker(t, count, 1, ""),
+	}
+
+	counts := make([]int, count)
+	const total = 2000
+	const step uint64 = 150
+	for i := uint64(1); i <= total; i++ {
+		pos := i * step
+		matches := 0
+		for idx, w := range workers {
+			if w.shouldProcess(itemAtPos(pos)) {
+				counts[idx]++
+				matches++
+			}
+		}
+		if matches != 1 {
+			t.Fatalf("event at pos %d matched %d shards, want exactly 1", pos, matches)
+		}
+	}
+
+	expected := total / int(count)
+	tolerance := expected / 5
+	for idx, c := range counts {
+		if c < expected-tolerance || c > expected+tolerance {
+			t.Errorf("shard %d processed %d events with %d-byte step positions, want ~%d (±%d)", idx, c, step, expected, tolerance)
 		}
 	}
 }

--- a/internal/binwatch/blsenderwork/blsenderwork_test.go
+++ b/internal/binwatch/blsenderwork/blsenderwork_test.go
@@ -1,0 +1,150 @@
+package blsenderwork
+
+import (
+	"testing"
+
+	"binwatch/internal/logger"
+	"binwatch/internal/pools"
+	"binwatch/internal/tmpl"
+)
+
+func newTestWorker(t *testing.T, count, index uint64, keyTmplStr string) *BLSenderWorkT {
+	t.Helper()
+	w := &BLSenderWorkT{
+		log:          logger.NewLogger(logger.GetLevel("error")),
+		shardEnabled: true,
+		shardCount:   count,
+		shardIndex:   index,
+	}
+	if keyTmplStr != "" {
+		tpl, err := tmpl.NewTemplate("test-key", keyTmplStr)
+		if err != nil {
+			t.Fatalf("unexpected template parse error: %v", err)
+		}
+		w.shardKeyTmpl = tpl
+	}
+	return w
+}
+
+func itemAtPos(pos uint64) *pools.RowEventItemT {
+	return &pools.RowEventItemT{Log: pools.RowEventItemLogT{BinlogPosition: pos}}
+}
+
+func itemWithID(id any) *pools.RowEventItemT {
+	return &pools.RowEventItemT{
+		Data: pools.RowEventItemDataT{
+			Rows: []map[string]any{{"id": id}},
+		},
+	}
+}
+
+// Sharding disabled: every event is processed.
+func TestShouldProcess_DisabledAcceptsAll(t *testing.T) {
+	w := &BLSenderWorkT{shardEnabled: false}
+	for pos := uint64(0); pos < 100; pos++ {
+		if !w.shouldProcess(itemAtPos(pos)) {
+			t.Fatalf("expected event at pos %d to be processed when sharding disabled", pos)
+		}
+	}
+}
+
+// BinlogPosition fallback: each event is routed to exactly one shard, and
+// every event lands on some shard (partition coverage).
+func TestShouldProcess_BinlogPositionPartitionsAllEvents(t *testing.T) {
+	const count uint64 = 3
+	workers := []*BLSenderWorkT{
+		newTestWorker(t, count, 0, ""),
+		newTestWorker(t, count, 1, ""),
+		newTestWorker(t, count, 2, ""),
+	}
+
+	counts := map[uint64]int{}
+	for pos := uint64(0); pos < 300; pos++ {
+		matches := 0
+		for idx, w := range workers {
+			if w.shouldProcess(itemAtPos(pos)) {
+				counts[uint64(idx)]++
+				matches++
+			}
+		}
+		if matches != 1 {
+			t.Fatalf("event at pos %d matched %d shards, want exactly 1", pos, matches)
+		}
+	}
+
+	// 300 events, 3 shards -> 100 each.
+	for idx, c := range counts {
+		if c != 100 {
+			t.Errorf("shard %d processed %d events, want 100 (BinlogPosition is sequential so distribution is exact)", idx, c)
+		}
+	}
+}
+
+// KeyTemplate-based hashing: same key always lands on the same shard
+// regardless of BinlogPosition.
+func TestShouldProcess_KeyTemplateRowAffinity(t *testing.T) {
+	const count uint64 = 3
+	const keyTmpl = `{{ (index .Data.Rows 0).id }}`
+
+	workers := []*BLSenderWorkT{
+		newTestWorker(t, count, 0, keyTmpl),
+		newTestWorker(t, count, 1, keyTmpl),
+		newTestWorker(t, count, 2, keyTmpl),
+	}
+
+	// For a given id, find which shard owns it on the first call,
+	// then verify it's stable across many subsequent calls.
+	for _, id := range []int{1, 42, 99, 12345, 7777777} {
+		var owner = -1
+		for idx, w := range workers {
+			if w.shouldProcess(itemWithID(id)) {
+				if owner != -1 {
+					t.Fatalf("id %d matched multiple shards (%d and %d)", id, owner, idx)
+				}
+				owner = idx
+			}
+		}
+		if owner == -1 {
+			t.Fatalf("id %d matched no shard", id)
+		}
+
+		// 50 repeats with same id should all hit the same shard.
+		for i := 0; i < 50; i++ {
+			if !workers[owner].shouldProcess(itemWithID(id)) {
+				t.Fatalf("id %d should consistently route to shard %d", id, owner)
+			}
+		}
+	}
+}
+
+// KeyTemplate distributes across all shards over a wide id space.
+func TestShouldProcess_KeyTemplateSpreadsLoad(t *testing.T) {
+	const count uint64 = 3
+	const keyTmpl = `{{ (index .Data.Rows 0).id }}`
+
+	workers := []*BLSenderWorkT{
+		newTestWorker(t, count, 0, keyTmpl),
+		newTestWorker(t, count, 1, keyTmpl),
+		newTestWorker(t, count, 2, keyTmpl),
+	}
+
+	counts := make([]int, count)
+	const total = 3000
+	for id := 1; id <= total; id++ {
+		for idx, w := range workers {
+			if w.shouldProcess(itemWithID(id)) {
+				counts[idx]++
+			}
+		}
+	}
+
+	// Expect roughly total/count per shard; allow 20% skew (FNV-1a on small
+	// integers is not uniform but is close enough at this scale).
+	expected := total / int(count)
+	tolerance := expected / 5
+	for idx, c := range counts {
+		if c < expected-tolerance || c > expected+tolerance {
+			t.Errorf("shard %d got %d events, want ~%d (±%d)", idx, c, expected, tolerance)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a top-level `sharding` config so the same binwatch YAML can run unmodified across N parallel pods, each handling 1/N of binlog events.
- `sharding.count` and `sharding.index` are designed to be injected via `\${ENV:VAR}\$` substitution (typically from a StatefulSet pod ordinal + replicaCount). One configMap for the whole deployment instead of N hand-maintained copies.
- Optional `sharding.keyTemplate` hashes a per-event key (FNV-1a 64) so all events for the same key (e.g. row PK) always land on the same shard. When unset, BinlogPosition is the bucket key (even distribution, no row affinity).

## Motivation

Scaling binwatch sender capacity today requires running N separate Helm releases with hand-edited `value: 0|1|2` shards. Any rescale (3 → 4) means coordinated edits across all configs at once. This change moves the shard identity from static YAML to runtime env vars so the same config rolls out to all replicas of a StatefulSet, and rescaling is just a `replicaCount` bump.

The companion chart change (env-var injection from the pod ordinal) ships in a separate PR.

## Example

\`\`\`yaml
sharding:
  enabled: true
  count: \${ENV:BINWATCH_SHARD_COUNT}\$   # = StatefulSet replicaCount
  index: \${ENV:BINWATCH_SHARD_INDEX}\$   # = pod ordinal (0..N-1)
  keyTemplate: '{{ (index .Data.Rows 0).id }}'  # hash by PK for row affinity
\`\`\`

## Test plan

- [x] \`go test ./...\` — unit tests cover: disabled passthrough, BinlogPosition partitioning (exact 1:1 routing, balanced counts), keyTemplate row-affinity (stable across many calls), keyTemplate spread across shards.
- [ ] Deploy a 3-replica StatefulSet against a sandbox MySQL and confirm shards distribute events evenly without duplicates.
- [ ] Validate fail-open behavior on bad keyTemplate via deliberate misconfiguration (logged warning, event still processed on one shard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event-sending behavior by conditionally skipping events per worker based on a hash; misconfiguration of shard `count/index` or key template could lead to uneven load or missing downstream writes.
> 
> **Overview**
> Adds a top-level `sharding` configuration (`enabled`, `count`, `index`, optional `keyTemplate`) and documents it in the sample YAML and `README`.
> 
> Updates `BinlogSenderWorker` to **partition events across N parallel instances** by hashing either a rendered `keyTemplate` (row-affinity) or the event `BinlogPosition` (fallback), validating shard settings at startup and skipping non-owned events in the send loop.
> 
> Introduces unit tests covering sharding disabled passthrough, balanced partitioning with hashed `BinlogPosition`, regression for even-step positions, and `keyTemplate`-based stable routing/spread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f1ea84b2b9a5b4c76e54081eb2930c00bcbfbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->