### PR TITLE
feat(chart): inject pod-ordinal env vars for sharding

### DIFF
--- a/charts/binwatch/Chart.yaml
+++ b/charts/binwatch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/binwatch/templates/statefulset-replica.yaml
+++ b/charts/binwatch/templates/statefulset-replica.yaml
@@ -55,6 +55,16 @@ spec:
           env:
             - name: SERVICE_NAME
               value: {{ include "binwatch.fullname" . }}-headless-replica
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BINWATCH_SHARD_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: BINWATCH_SHARD_COUNT
+              value: {{ .Values.replicaCount | quote }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/binwatch/templates/statefulset.yaml
+++ b/charts/binwatch/templates/statefulset.yaml
@@ -54,6 +54,21 @@ spec:
           env:
             - name: SERVICE_NAME
               value: {{ include "binwatch.fullname" . }}-headless
+            # Shard identity for the binwatch `sharding` config block.
+            # POD_NAME -> consumed by binwatch as ${ENV:POD_NAME}$ to derive
+            # the ordinal at runtime if needed. BINWATCH_SHARD_INDEX is the
+            # canonical source, exposed via the StatefulSet pod-index label
+            # (Kubernetes 1.28+; stable in 1.30).
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BINWATCH_SHARD_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: BINWATCH_SHARD_COUNT
+              value: {{ .Values.replicaCount | quote }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/binwatch/values.yaml
+++ b/charts/binwatch/values.yaml
@@ -111,6 +111,13 @@ tolerations: []
 
 affinity: {}
 
+# The chart always injects, on top of whatever is set here:
+#   POD_NAME              - the pod name (downward API: metadata.name)
+#   BINWATCH_SHARD_INDEX  - pod ordinal (downward API: apps.kubernetes.io/pod-index label, K8s 1.28+)
+#   BINWATCH_SHARD_COUNT  - replicaCount as string
+# These are consumed by binwatch's `sharding` config via ${ENV:VAR}$
+# substitution. Safe to ignore if sharding is disabled in the binwatch
+# config.
 env: []
 # - name: MY_ENV_VAR
 #   value: my-env-var-value


### PR DESCRIPTION
## Summary

- Injects \`POD_NAME\`, \`BINWATCH_SHARD_INDEX\` and \`BINWATCH_SHARD_COUNT\` env vars into every binwatch container via the Downward API, both in the main and HA-replica StatefulSets.
- \`BINWATCH_SHARD_INDEX\` is sourced from the \`apps.kubernetes.io/pod-index\` StatefulSet label (Kubernetes 1.28+, stable in 1.30).
- Bumps chart version to \`0.3.0\`.

Paired with the binwatch \`sharding\` feature in #14: a single Helm release at \`replicaCount=N\` replaces N hand-maintained value-files / releases (\`mod0/1/2\`...). Each pod renders the same \`sharding.{count,index}\` config from its own env vars.

## Compatibility

If the binwatch image does not implement the \`sharding\` block (i.e. older images), the extra env vars are inert — set on the pod but never referenced by the config. No breakage either way.

## Test plan

- [x] \`helm template ... --set replicaCount=3\` renders the three env vars correctly on the StatefulSet pod spec.
- [ ] Deploy alongside binwatch image with #14 merged and verify pods log \`shard X of N\` distinctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod environment for all `binwatch` StatefulSet containers and relies on the `apps.kubernetes.io/pod-index` label being present; misconfigured/older clusters or apps that start using these vars could see behavior changes. Otherwise it’s a small, Helm-only change with no data/security impact.
> 
> **Overview**
> Adds automatic sharding identity env vars (`POD_NAME`, `BINWATCH_SHARD_INDEX`, `BINWATCH_SHARD_COUNT`) to the container `env` in both the main and HA replica `StatefulSet` templates, using the Downward API and `replicaCount`.
> 
> Updates `values.yaml` docs to note these always-injected variables, and bumps the chart version to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96638f26e2632cc1b176698b63fba3728b740dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->