### PR TITLE
feat: add TLS/mTLS support for the source database connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ go.work
 *~
 
 int.test/
+
+# Integration test generated certificates
+test/integration/certs/*.pem

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,18 @@ WATCHER_FLAGS?=--config $(WATCHER_CONFIG)
 run-watcher: fmt vet ## Run a command from your host (define WATCHER_FLAGS to custom run watcher).
 	go run cmd/main.go watcher $(WATCHER_FLAGS)
 
+##@ Integration test
+
+.PHONY: int-test-up
+int-test-up: ## Start the mTLS integration environment (mysql 8.0 + binwatch + traffic + webhook).
+	test/integration/certs/generate-certs.sh
+	cd test/integration && $(CONTAINER_TOOL) compose up --build -d
+
+.PHONY: int-test-logs
+int-test-logs: ## Follow binwatch and webhook logs from the integration environment.
+	cd test/integration && $(CONTAINER_TOOL) compose logs -f binwatch webhook
+
+.PHONY: int-test-down
+int-test-down: ## Tear down the integration environment and its volumes.
+	cd test/integration && $(CONTAINER_TOOL) compose down -v
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ List of fields in v1alpha2 configuration:
 | `source.port`                         | `uint32`              | Port of the source database.                                                          |
 | `source.user`                         | `string`              | Username for the source database.                                                     |
 | `source.password`                     | `string`              | Password for the source database.                                                     |
+| `source.tls.enabled`                  | `bool`                | Enables TLS for the connection to the source database.                                |
+| `source.tls.ca`                       | `string`              | Path to the CA certificate used to verify the server certificate.                     |
+| `source.tls.cert`                     | `string`              | Path to the client certificate for mTLS.                                              |
+| `source.tls.key`                      | `string`              | Path to the client private key for mTLS.                                              |
+| `source.tls.serverName`               | `string`              | Hostname expected in the server certificate. Defaults to `source.host`.               |
+| `source.tls.insecureSkipVerify`       | `bool`                | Skip hostname check; the chain is still verified when a CA is set (CloudSQL).         |
 | `source.dbTables`                     | `map[string][]string` | Map of database names to tables to monitor (e.g., { "db": ["table"] }).               |
 | `source.readTimeout`                  | `duration`            | Maximum time to wait for a read operation.                                            |
 | `source.heartbeatPeriod`              | `duration`            | Interval between heartbeat messages.                                                  |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ List of fields in v1alpha2 configuration:
 | `source.tls.cert`                     | `string`              | Path to the client certificate for mTLS.                                              |
 | `source.tls.key`                      | `string`              | Path to the client private key for mTLS.                                              |
 | `source.tls.serverName`               | `string`              | Hostname expected in the server certificate. Defaults to `source.host`.               |
-| `source.tls.insecureSkipVerify`       | `bool`                | Skip hostname check; the chain is still verified when a CA is set (CloudSQL).         |
+| `source.tls.insecureSkipVerify`       | `bool`                | Skip hostname check. With `ca` the chain is verified; without it, nothing is.         |
 | `source.dbTables`                     | `map[string][]string` | Map of database names to tables to monitor (e.g., { "db": ["table"] }).               |
 | `source.readTimeout`                  | `duration`            | Maximum time to wait for a read operation.                                            |
 | `source.heartbeatPeriod`              | `duration`            | Interval between heartbeat messages.                                                  |

--- a/api/v1alpha2/config.go
+++ b/api/v1alpha2/config.go
@@ -121,6 +121,8 @@ type SourceT struct {
 // certificate (mTLS). InsecureSkipVerify disables hostname verification;
 // when a CA is set, the certificate chain is still verified against it
 // (needed for CloudSQL, whose server certs do not include the instance IP).
+// Without a CA, InsecureSkipVerify disables server verification entirely
+// (encrypted but unauthenticated — only for migration/testing).
 type SourceTLST struct {
 	Enabled            bool   `yaml:"enabled"`
 	CA                 string `yaml:"ca"`

--- a/api/v1alpha2/config.go
+++ b/api/v1alpha2/config.go
@@ -108,11 +108,26 @@ type SourceT struct {
 	Port     uint32              `yaml:"port"`
 	User     string              `yaml:"user"`
 	Password string              `yaml:"password"`
+	TLS      SourceTLST          `yaml:"tls"`
 	DBTables map[string][]string `yaml:"dbTables"`
 
 	ReadTimeout     time.Duration `yaml:"readTimeout"`
 	HeartbeatPeriod time.Duration `yaml:"heartbeatPeriod"`
 	StartLocation   LocationT     `yaml:"startLocation"`
+}
+
+// SourceTLST configures TLS for the connection to the source database.
+// CA enables server certificate verification and Cert/Key present a client
+// certificate (mTLS). InsecureSkipVerify disables hostname verification;
+// when a CA is set, the certificate chain is still verified against it
+// (needed for CloudSQL, whose server certs do not include the instance IP).
+type SourceTLST struct {
+	Enabled            bool   `yaml:"enabled"`
+	CA                 string `yaml:"ca"`
+	Cert               string `yaml:"cert"`
+	Key                string `yaml:"key"`
+	ServerName         string `yaml:"serverName"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
 }
 
 // LocationT

--- a/docs/binwatch.v1alpha2.yaml
+++ b/docs/binwatch.v1alpha2.yaml
@@ -34,7 +34,7 @@ source:
     cert: "" # path to the client certificate for mTLS (e.g. CloudSQL client-cert.pem)
     key: "" # path to the client private key for mTLS (e.g. CloudSQL client-key.pem)
     serverName: "" # hostname expected in the server certificate, defaults to source.host
-    insecureSkipVerify: false # skip hostname verification; with a CA set, the chain is still verified (required for CloudSQL, whose certs do not include the instance IP)
+    insecureSkipVerify: false # skip hostname verification; with a CA set, the chain is still verified (required for CloudSQL, whose certs do not include the instance IP); WITHOUT a CA the server cert is NOT verified at all (insecure, only for migration/testing)
   dbTables: {} # map of databases tables to watch
   # dbTables:
   #   testdb: [users]

--- a/docs/binwatch.v1alpha2.yaml
+++ b/docs/binwatch.v1alpha2.yaml
@@ -28,6 +28,13 @@ source:
   port: 3306 # database port
   user: root # database user
   password: test # database password
+  tls:
+    enabled: false # enable TLS for the connection to the source database
+    ca: "" # path to the CA certificate to verify the server certificate (e.g. CloudSQL server-ca.pem)
+    cert: "" # path to the client certificate for mTLS (e.g. CloudSQL client-cert.pem)
+    key: "" # path to the client private key for mTLS (e.g. CloudSQL client-key.pem)
+    serverName: "" # hostname expected in the server certificate, defaults to source.host
+    insecureSkipVerify: false # skip hostname verification; with a CA set, the chain is still verified (required for CloudSQL, whose certs do not include the instance IP)
   dbTables: {} # map of databases tables to watch
   # dbTables:
   #   testdb: [users]

--- a/internal/binwatch/blreaderwork/blreaderwork.go
+++ b/internal/binwatch/blreaderwork/blreaderwork.go
@@ -54,6 +54,9 @@ func NewBinlogReaderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 	if err != nil {
 		return w, err
 	}
+	if w.cfg.Source.TLS.Enabled && w.cfg.Source.TLS.InsecureSkipVerify && w.cfg.Source.TLS.CA == "" {
+		w.log.Warn("source TLS insecureSkipVerify is set without a CA: the connection is encrypted but the server certificate will NOT be verified", utils.GetBasicLogExtraFields(componentName), nil)
+	}
 
 	w.mysql.blSyncer = replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 		Flavor:          w.cfg.Source.Flavor,

--- a/internal/binwatch/blreaderwork/blreaderwork.go
+++ b/internal/binwatch/blreaderwork/blreaderwork.go
@@ -2,6 +2,7 @@ package blreaderwork
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"reflect"
 	"strings"
@@ -37,6 +38,7 @@ type mysqlT struct {
 	blStream *replication.BinlogStreamer
 	blLoc    mysql.Position
 	colNames map[string][]string
+	tlsCfg   *tls.Config
 }
 
 func NewBinlogReaderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cach cache.CacheI) (w *BLReaderWorkT, err error) {
@@ -48,6 +50,11 @@ func NewBinlogReaderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 		cach:   cach,
 	}
 
+	w.mysql.tlsCfg, err = utils.GetTLSConfig(w.cfg.Source.TLS, w.cfg.Source.Host)
+	if err != nil {
+		return w, err
+	}
+
 	w.mysql.blSyncer = replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 		Flavor:          w.cfg.Source.Flavor,
 		ServerID:        w.cfg.Source.ServerID,
@@ -57,17 +64,19 @@ func NewBinlogReaderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 		Password:        w.cfg.Source.Password,
 		ReadTimeout:     w.cfg.Source.ReadTimeout,
 		HeartbeatPeriod: w.cfg.Source.HeartbeatPeriod,
+		TLSConfig:       w.mysql.tlsCfg,
 		Logger:          logger.DummyLogger{},
 	})
 
 	// Get Columns
 
 	w.mysql.colNames, err = utils.GetTableColumns(utils.DBOptions{
-		Flavor: w.cfg.Source.Flavor,
-		User:   w.cfg.Source.User,
-		Pass:   w.cfg.Source.Password,
-		Host:   w.cfg.Source.Host,
-		Port:   w.cfg.Source.Port,
+		Flavor:    w.cfg.Source.Flavor,
+		User:      w.cfg.Source.User,
+		Pass:      w.cfg.Source.Password,
+		Host:      w.cfg.Source.Host,
+		Port:      w.cfg.Source.Port,
+		TLSConfig: w.mysql.tlsCfg,
 	}, w.cfg.Source.DBTables)
 	if err != nil {
 		return w, err
@@ -96,12 +105,13 @@ func NewBinlogReaderWork(cfg *v1alpha2.ConfigT, rePool *pools.RowEventPoolT, cac
 
 	if w.mysql.blLoc.Name == "" {
 		w.mysql.blLoc, err = utils.GetCurrentBinlogLocation(&canal.Config{
-			ServerID: w.cfg.Source.ServerID,
-			Flavor:   w.cfg.Source.Flavor,
-			Addr:     fmt.Sprintf("%s:%d", w.cfg.Source.Host, w.cfg.Source.Port),
-			User:     w.cfg.Source.User,
-			Password: w.cfg.Source.Password,
-			Logger:   logger.DummyLogger{},
+			ServerID:  w.cfg.Source.ServerID,
+			Flavor:    w.cfg.Source.Flavor,
+			Addr:      fmt.Sprintf("%s:%d", w.cfg.Source.Host, w.cfg.Source.Port),
+			User:      w.cfg.Source.User,
+			Password:  w.cfg.Source.Password,
+			TLSConfig: w.mysql.tlsCfg,
+			Logger:    logger.DummyLogger{},
 		})
 		if err != nil {
 			return w, err
@@ -154,12 +164,13 @@ func (w *BLReaderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 
 							// Get current binlog location without cache in order to avoid infinite loop
 							w.mysql.blLoc, err = utils.GetCurrentBinlogLocation(&canal.Config{
-								ServerID: w.cfg.Source.ServerID,
-								Flavor:   w.cfg.Source.Flavor,
-								Addr:     fmt.Sprintf("%s:%d", w.cfg.Source.Host, w.cfg.Source.Port),
-								User:     w.cfg.Source.User,
-								Password: w.cfg.Source.Password,
-								Logger:   logger.DummyLogger{},
+								ServerID:  w.cfg.Source.ServerID,
+								Flavor:    w.cfg.Source.Flavor,
+								Addr:      fmt.Sprintf("%s:%d", w.cfg.Source.Host, w.cfg.Source.Port),
+								User:      w.cfg.Source.User,
+								Password:  w.cfg.Source.Password,
+								TLSConfig: w.mysql.tlsCfg,
+								Logger:    logger.DummyLogger{},
 							})
 							if err != nil {
 								w.log.Error("error getting current binlog location", extra, err, true)
@@ -175,6 +186,7 @@ func (w *BLReaderWorkT) Run(wg *sync.WaitGroup, ctx context.Context) {
 								Password:        w.cfg.Source.Password,
 								ReadTimeout:     w.cfg.Source.ReadTimeout,
 								HeartbeatPeriod: w.cfg.Source.HeartbeatPeriod,
+								TLSConfig:       w.mysql.tlsCfg,
 								Logger:          logger.DummyLogger{},
 							})
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,18 +1,21 @@
 package utils
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"fmt"
 	"os"
 	"regexp"
 	"strings"
 
+	"binwatch/api/v1alpha2"
 	"binwatch/internal/logger"
 
 	"github.com/go-mysql-org/go-mysql/canal"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
-	_ "github.com/go-sql-driver/mysql"
+	mysqldrv "github.com/go-sql-driver/mysql"
 )
 
 const (
@@ -89,17 +92,102 @@ func GetDMLOperationFromRowsEventType(et replication.EventType) (eType string) {
 	return ""
 }
 
+// GetTLSConfig builds the TLS configuration used to connect to the source
+// database: the CA verifies the server certificate and Cert/Key present a
+// client certificate (mTLS). ServerName is required by the TLS handshake
+// when verification is enabled; it defaults to the source host unless
+// overridden in the config. Returns nil when TLS is disabled.
+func GetTLSConfig(cfg v1alpha2.SourceTLST, defaultServerName string) (*tls.Config, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	serverName := cfg.ServerName
+	if serverName == "" {
+		serverName = defaultServerName
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         serverName,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+	}
+
+	if cfg.CA != "" {
+		caPEM, err := os.ReadFile(cfg.CA)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read TLS CA file %q: %w", cfg.CA, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("unable to parse any certificate from TLS CA file %q", cfg.CA)
+		}
+		tlsCfg.RootCAs = pool
+
+		// CloudSQL server certificates do not include the instance IP in the
+		// SANs, so standard hostname verification fails. With
+		// insecureSkipVerify enabled the chain is still verified against the
+		// CA here, only the hostname check is skipped.
+		if cfg.InsecureSkipVerify {
+			tlsCfg.VerifyPeerCertificate = verifyPeerCertAgainstCA(pool)
+		}
+	}
+
+	if cfg.Cert != "" || cfg.Key != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.Cert, cfg.Key)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load TLS client keypair (cert %q, key %q): %w", cfg.Cert, cfg.Key, err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsCfg, nil
+}
+
+func verifyPeerCertAgainstCA(pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return fmt.Errorf("no server certificate presented")
+		}
+		certs := make([]*x509.Certificate, 0, len(rawCerts))
+		for _, raw := range rawCerts {
+			cert, err := x509.ParseCertificate(raw)
+			if err != nil {
+				return fmt.Errorf("unable to parse server certificate: %w", err)
+			}
+			certs = append(certs, cert)
+		}
+		opts := x509.VerifyOptions{
+			Roots:         pool,
+			Intermediates: x509.NewCertPool(),
+		}
+		for _, cert := range certs[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+		_, err := certs[0].Verify(opts)
+		return err
+	}
+}
+
 type DBOptions struct {
-	Flavor string
-	User   string
-	Pass   string
-	Host   string
-	Port   uint32
+	Flavor    string
+	User      string
+	Pass      string
+	Host      string
+	Port      uint32
+	TLSConfig *tls.Config
 }
 
 // GetTableColumns TODO
 func GetTableColumns(ops DBOptions, dbTables map[string][]string) (dbTableColsNames map[string][]string, err error) {
 	dsn := fmt.Sprintf("%s:%s@(%s:%d)/", ops.User, ops.Pass, ops.Host, ops.Port)
+	if ops.TLSConfig != nil {
+		err = mysqldrv.RegisterTLSConfig("binwatch", ops.TLSConfig)
+		if err != nil {
+			return dbTableColsNames, err
+		}
+		dsn += "?tls=binwatch"
+	}
 	db, err := sql.Open(ops.Flavor, dsn)
 	if err != nil {
 		return dbTableColsNames, err

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,61 @@
+# Integration test: binwatch + MySQL 8.0 with mTLS
+
+End-to-end environment to validate the whole flow with TLS/mTLS enabled:
+
+```text
+traffic (random INSERT/UPDATE/DELETE/SELECT, mTLS)
+   └──> mysql:8.0 (require_secure_transport=ON, users REQUIRE X509)
+           └──binlog──> binwatch (source.tls: ca + client cert)
+                            └──> webhook (http echo, prints received events)
+```
+
+Both MySQL users (`binwatch` and `traffic`) are created with `REQUIRE X509`,
+so connections are rejected unless the client presents a certificate signed
+by the test CA — this proves the client certificate is actually being used,
+not just the server one.
+
+The server certificate includes `SAN: DNS:mysql`, so binwatch runs with full
+verification (`insecureSkipVerify: false`).
+
+## Usage
+
+From the repository root:
+
+```bash
+make int-test-up      # generate certs, build image and start everything
+make int-test-logs    # follow binwatch + webhook logs (events arriving)
+make int-test-down    # tear down (volumes included)
+```
+
+Or manually:
+
+```bash
+cd test/integration
+./certs/generate-certs.sh
+docker compose up --build -d
+docker compose logs -f binwatch webhook
+```
+
+## What to check
+
+- `binwatch` logs show `start sync process` and `success adding event in pool`
+  for the INSERTs/UPDATEs/DELETEs made by `traffic` (SELECTs must NOT appear:
+  they don't produce binlog events).
+- `webhook` logs print the JSON events rendered by the route template.
+- To verify mTLS is enforced, try connecting without a client certificate:
+
+  ```bash
+  docker compose exec mysql mysql -h127.0.0.1 -ubinwatch -pbinwatch \
+    --ssl-mode=REQUIRED -e 'SELECT 1'
+  # ERROR 1045: Access denied (no X509 certificate presented)
+  ```
+
+## Files
+
+| Path | Purpose |
+|:-----|:--------|
+| `docker-compose.yaml` | The four services described above |
+| `certs/generate-certs.sh` | Creates CA + server + client certs (gitignored `*.pem`) |
+| `mysql/init.sql` | Schema `testdb.users` + users with `REQUIRE X509` |
+| `binwatch/config.yaml` | binwatch config with `source.tls` enabled |
+| `traffic/traffic.sh` | Random DML/SELECT loop over mTLS |

--- a/test/integration/binwatch/config.yaml
+++ b/test/integration/binwatch/config.yaml
@@ -1,0 +1,56 @@
+logger:
+  level: debug
+
+server:
+  id: binwatch-integration
+  host: "0.0.0.0"
+  port: 8080
+  stopInError: false
+  restartSyncerOnError: true
+  senderWorkers: 1
+  pool:
+    size: 20
+    itemByRow: true
+  cache:
+    enabled: false
+
+source:
+  flavor: mysql
+  serverID: 100
+  host: mysql
+  port: 3306
+  user: binwatch
+  password: binwatch
+  tls:
+    enabled: true
+    ca: /certs/ca.pem
+    cert: /certs/client-cert.pem
+    key: /certs/client-key.pem
+    # The server cert includes SAN DNS:mysql, so full verification works here.
+    insecureSkipVerify: false
+  dbTables:
+    testdb: [users]
+  readTimeout: 90s
+  heartbeatPeriod: 60s
+
+connectors:
+- name: echo
+  type: webhook
+  webhook:
+    url: http://webhook:8080/events
+    method: POST
+    headers:
+      "Content-Type": "application/json"
+
+routes:
+- name: users-all
+  connector: echo
+  operations: ["INSERT", "UPDATE", "DELETE"]
+  dbTable: "testdb.users"
+  template: |
+    {
+      "operation": "{{ .Data.Operation }}",
+      "database": "{{ .Data.Database }}",
+      "table": "{{ .Data.Table }}",
+      "rows": {{- .Data.Rows | toJson }}
+    }

--- a/test/integration/certs/generate-certs.sh
+++ b/test/integration/certs/generate-certs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Generates a test CA, a MySQL server certificate (SAN: mysql, localhost) and
+# a client certificate for mTLS. All files land next to this script and are
+# gitignored. Certs must be world-readable: the mysql container runs as uid
+# 999 and binwatch as root inside its own container.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+DAYS=3650
+
+if [[ -f ca.pem && -f server-cert.pem && -f client-cert.pem ]]; then
+  echo "certificates already generated, remove *.pem to regenerate"
+  exit 0
+fi
+
+# CA
+openssl genrsa -out ca-key.pem 2048
+openssl req -new -x509 -nodes -days "$DAYS" -key ca-key.pem \
+  -subj "/CN=binwatch-integration-ca" -out ca.pem
+
+# Server (SAN includes the compose service name so hostname verification works)
+openssl req -newkey rsa:2048 -nodes -keyout server-key.pem \
+  -subj "/CN=mysql" -out server-req.pem
+openssl x509 -req -in server-req.pem -days "$DAYS" \
+  -CA ca.pem -CAkey ca-key.pem -set_serial 01 \
+  -extfile <(printf "subjectAltName=DNS:mysql,DNS:localhost,IP:127.0.0.1") \
+  -out server-cert.pem
+
+# Client (mTLS)
+openssl req -newkey rsa:2048 -nodes -keyout client-key.pem \
+  -subj "/CN=binwatch-client" -out client-req.pem
+openssl x509 -req -in client-req.pem -days "$DAYS" \
+  -CA ca.pem -CAkey ca-key.pem -set_serial 02 \
+  -out client-cert.pem
+
+rm -f server-req.pem client-req.pem
+chmod 644 ./*.pem
+
+echo "certificates generated:"
+openssl verify -CAfile ca.pem server-cert.pem client-cert.pem

--- a/test/integration/docker-compose.yaml
+++ b/test/integration/docker-compose.yaml
@@ -1,0 +1,59 @@
+services:
+  mysql:
+    image: mysql:8.0
+    command:
+      - --server-id=1
+      - --binlog_format=ROW
+      - --require_secure_transport=ON
+      - --ssl-ca=/certs/ca.pem
+      - --ssl-cert=/certs/server-cert.pem
+      - --ssl-key=/certs/server-key.pem
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: testdb
+    volumes:
+      - ./certs:/certs:ro
+      - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-uroot", "-proot", "--silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  webhook:
+    image: mendhak/http-https-echo:31
+    environment:
+      HTTP_PORT: "8080"
+    ports:
+      - "8085:8080"
+
+  binwatch:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    command: ["--config", "/app/config.yaml"]
+    volumes:
+      - ./binwatch/config.yaml:/app/config.yaml:ro
+      - ./certs:/certs:ro
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      webhook:
+        condition: service_started
+
+  traffic:
+    image: mysql:8.0
+    entrypoint: ["/traffic.sh"]
+    volumes:
+      - ./traffic/traffic.sh:/traffic.sh:ro
+      - ./certs:/certs:ro
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy

--- a/test/integration/mysql/init.sql
+++ b/test/integration/mysql/init.sql
@@ -1,0 +1,25 @@
+-- Schema and users for the binwatch integration test.
+-- Both users REQUIRE X509: connections without a valid client certificate
+-- signed by the CA are rejected, which proves mTLS end to end.
+
+CREATE DATABASE IF NOT EXISTS testdb;
+USE testdb;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(64) NOT NULL,
+    email VARCHAR(128) NOT NULL,
+    score INT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Replication user for binwatch
+CREATE USER 'binwatch'@'%' IDENTIFIED BY 'binwatch' REQUIRE X509;
+GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'binwatch'@'%';
+GRANT SELECT ON testdb.* TO 'binwatch'@'%';
+
+-- DML user for the traffic generator
+CREATE USER 'traffic'@'%' IDENTIFIED BY 'traffic' REQUIRE X509;
+GRANT SELECT, INSERT, UPDATE, DELETE ON testdb.* TO 'traffic'@'%';
+
+FLUSH PRIVILEGES;

--- a/test/integration/traffic/traffic.sh
+++ b/test/integration/traffic/traffic.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Random DML/SELECT traffic generator against the integration MySQL, always
+# over mTLS. Weights: 40% INSERT, 25% UPDATE, 15% DELETE, 20% SELECT.
+set -u
+
+MYSQL=(mysql -h mysql -utraffic -ptraffic
+  --ssl-ca=/certs/ca.pem
+  --ssl-cert=/certs/client-cert.pem
+  --ssl-key=/certs/client-key.pem
+  --ssl-mode=VERIFY_IDENTITY
+  testdb)
+
+run() {
+  "${MYSQL[@]}" -e "$1" 2>&1 | grep -v "Using a password"
+}
+
+echo "traffic generator started (mTLS, VERIFY_IDENTITY)"
+
+i=0
+while true; do
+  i=$((i + 1))
+  dice=$((RANDOM % 100))
+
+  if [ "$dice" -lt 40 ]; then
+    name="user-$RANDOM"
+    run "INSERT INTO users (name, email, score) VALUES ('$name', '$name@example.com', $((RANDOM % 1000)));"
+    echo "[$i] INSERT $name"
+  elif [ "$dice" -lt 65 ]; then
+    run "UPDATE users SET score = $((RANDOM % 1000)) ORDER BY RAND() LIMIT 1;"
+    echo "[$i] UPDATE random row"
+  elif [ "$dice" -lt 80 ]; then
+    run "DELETE FROM users ORDER BY RAND() LIMIT 1;"
+    echo "[$i] DELETE random row"
+  else
+    count=$(run "SELECT COUNT(*) FROM users;" | tail -1)
+    echo "[$i] SELECT count=$count"
+  fi
+
+  sleep "$((RANDOM % 3 + 1))"
+done


### PR DESCRIPTION
## What

Adds a `source.tls` section to the v1alpha2 config to secure the connection
to the source database with TLS/mTLS:

- `ca`: verifies the server certificate
- `cert`/`key`: client certificate (mTLS)
- `serverName`: hostname expected in the server cert (defaults to `source.host`)
- `insecureSkipVerify`: skips the hostname check only — when a `ca` is set,
  the certificate chain is still verified against it (needed for CloudSQL,
  whose server certs don't include the instance IP in their SANs)

The TLS config is wired into every connection point: the binlog syncer
(initial + restart-on-error), the canal position lookup and the column
discovery client.

## Integration test

New `test/integration/` docker compose environment (`make int-test-up`):
MySQL 8.0 with `require_secure_transport=ON` and `REQUIRE X509` users,
binwatch built from the repo, an http echo connector and a random DML
traffic generator.

Verified scenarios:

| Scenario | Result |
|---|---|
| DNS host, cert with matching SAN, strict verification | ✅ |
| IP host, IP present in cert SANs, strict verification | ✅ |
| IP host not in cert + `serverName` override | ✅ |
| CloudSQL-like: `insecureSkipVerify` + CA (chain still verified) | ✅ |
| Wrong CA with `insecureSkipVerify` enabled | ❌ rejected |
| Connection without client cert against `REQUIRE X509` user | ❌ rejected |

Replication session confirmed encrypted (`TLS_AES_128_GCM_SHA256` in
`performance_schema`).

Refs: freepik-company/sre#3212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches replication and DB connection setup (auth-adjacent); misconfigured TLS or `insecureSkipVerify` without a CA could weaken verification, though defaults keep TLS off and unsafe combos are warned.
> 
> **Overview**
> Adds **`source.tls`** to v1alpha2 so binwatch can connect to the source database over TLS and optional mTLS (CA, client cert/key, `serverName`, `insecureSkipVerify`).
> 
> **`utils.GetTLSConfig`** builds the `*tls.Config` (TLS 1.2+, CA trust, client certs, and a CloudSQL-style path where `insecureSkipVerify` still verifies the chain against the CA). That config is passed into the binlog syncer (startup and error restart), canal binlog position lookup, and SQL column discovery via **`DBOptions.TLSConfig`**.
> 
> Docs and sample YAML are updated; a warning is logged when `insecureSkipVerify` is set without a CA.
> 
> A new **`test/integration`** Docker Compose stack (MySQL 8 with `require_secure_transport` and `REQUIRE X509`, cert generation script, traffic generator, webhook) is wired through **`make int-test-up` / `int-test-logs` / `int-test-down`**; generated `*.pem` files are gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49078b999a938dd6aea04d9efa85a7bdd82d7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->